### PR TITLE
wip: build extensions with zig & nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,40 @@
+{
+  pkgs,
+  system,
+  stdenv,
+  ...
+}: {
+  pname ? "record-duckdb-extension",
+  version ? "0.6.38",
+  shas ? {
+    aarch64-darwin = "15wqxy577kgfyn6amm0jrkm034zg8di4ynk4k9mz7x6jq9k294x8";
+    x86_64-darwin = "07rh67s51nyawmvyq9pbsqxfg04gznx43jxisiiii117w852j2bi";
+    aarch64-linux = "087418lm1hbknafh3hs3q9s2pnmjkm4pdi0nm5k17xhlnl7i80d2";
+    x86_64-linux = "0960a8x6xal0xv4wm89f6mcxg59sf35vj257yp0wg3c28b71cpkx";
+  },
+}: let
+  os =
+    if stdenv.isDarwin
+    then "Darwin"
+    else "Linux";
+  arch =
+    if pkgs.lib.hasInfix "aarch64" system
+    then "arm64"
+    else "x86_64";
+  file = "flytectl_${os}_${arch}.tar.gz";
+in
+  stdenv.mkDerivation {
+    pname = pname;
+    version = version;
+    src = pkgs.fetchzip {
+      url = "https://github.com/flyteorg/flytectl/releases/download/v${version}/${file}";
+      sha256 = shas.${system};
+      stripRoot = false;
+    };
+
+    installPhase = "mkdir -p $out/bin; cp flytectl $out/bin";
+
+    checkPhase = ''
+      flytectl version | grep ${version}
+    '';
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
         inherit system;
         overlays = [
           zig-overlay.overlays.default
+          self.overlay
         ];
       };
     in rec {
@@ -46,6 +47,7 @@
             -Doptimize=Debug \
             -Dbuild-shell
         '';
+        default = pkgs.record-duckdb-extension {};
       };
 
       # nix run
@@ -77,5 +79,12 @@
       };
     });
   in
-    outputs;
+    outputs
+    // {
+      # Overlay that can be imported so you can access the packages
+      # using record-duckdb-extension.overlay
+      overlay = final: prev: {
+        record-duckdb-extension = prev.pkgs.callPackage ./default.nix {};
+      };
+    };
 }


### PR DESCRIPTION
- [ ] build with zig
  * [ ] icu_extension
  * [ ] parquet_extension
  * [ ] tpch_extension
  * [ ] tpcds_extension
  * [ ] fts_extension
  * [ ] httpfs_extension
  * [ ] visualizer_extension
  * [ ] json_extension
  * [ ] jemalloc_extension
  * [ ] excel_extension
  * [ ] sqlsmith_extension
  * [ ] autocomplete_extension
  * [ ] record_extension
  * [ ] libduckdb
  * [ ] unittest
  * [ ] imdb
- [ ] ensure includes are correct
- [ ] ensure linkages are correct
- [ ] ensure tests pass
- [ ] add zig build run step for shell
- [ ] add zig build run step for libduckdb
- [ ] add zig build run step for record_extension
- [ ] add zig build run step for unittest
- [ ] run zig build shell as default app in nix